### PR TITLE
CPAN Pull Request Challenge 2015

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -2,6 +2,7 @@ lib/GD/SecurityImage.pm
 lib/GD/SecurityImage/GD.pm
 lib/GD/SecurityImage/Magick.pm
 lib/GD/SecurityImage/Styles.pm
+t/02-securityimage.t
 t/03-info_text.t
 t/04-backend.t
 t/05-version.t

--- a/lib/GD/SecurityImage.pm
+++ b/lib/GD/SecurityImage.pm
@@ -69,22 +69,13 @@ sub new {
 
    my %options = $self->_new_options( %opt );
 
-   if ( $opt{text_location}
-      && ref $opt{text_location}
-      && ref $opt{text_location} eq 'HASH' ) {
-      $self->{_TEXT_LOCATION_} = { %{$opt{text_location}}, _place_ => 1 };
-   }
-   else {
-      $self->{_TEXT_LOCATION_}{_place_} = 0;
-   }
-
    $self->{_RNDMAX_} = $options{rndmax};
 
    $self->{$_} = $options{$_} foreach keys %options;
 
    if ( $self->{angle} ) { # validate angle
       $self->{angle} = FULL_CIRCLE + $self->{angle} if $self->{angle} < 0;
-      if ( $self->{angle} > FULL_CIRCLE ) {
+      if ( $self->{angle} > FULL_CIRCLE || $self->{angle} < 0) {
          croak 'Angle parameter can take values in the range -360..360';
       }
    }
@@ -490,7 +481,7 @@ for migration from C<Authen::Captcha> to C<GD::SecurityImage>.
 This module is B<just an image generator>. Not a I<captcha handler>.
 The validation of the generated graphic is left to your programming 
 taste. But there are some I<captcha handlers> for several Perl FrameWorks.
-If you are an user of one of these frameworks, see  
+If you are a user of one of these frameworks, see
 L</"GD::SecurityImage Implementations"> in L</"SEE ALSO"> section
 for information.
 
@@ -533,7 +524,7 @@ The height of the image (in pixels).
 =item ptsize
 
 Numerical value. The point size of the ttf character. 
-Only necessarry if you want to use a ttf font in the image.
+Only necessary if you want to use a ttf font in the image.
 
 =item lines
 

--- a/lib/GD/SecurityImage/GD.pm
+++ b/lib/GD/SecurityImage/GD.pm
@@ -25,6 +25,8 @@ use constant FORMATS     => qw( png gif jpeg );
 use constant GDFONTS     => qw( Small Large MediumBold Tiny Giant );
 
 use constant RGB_WHITE   => (255, 255, 255);
+use constant RGB_BLACK   => (0, 0, 0 );
+
 use constant BOX_SIZE    => 7;
 
 use constant ROTATE_NONE             =>   0;
@@ -243,8 +245,9 @@ sub insert_text {
 sub place_gd {
    my($self, $key, $tx, $ty) = @_;
    my $tl    = $self->{_TEXT_LOCATION_};
-   my $black = $self->cconvert($self->{_COLOR_}{text});
-   my $white = $self->cconvert($tl->{scolor});
+   my $c     = $self->{_COLOR_} || {};
+   my $black = $self->cconvert( $c->{text}    ? $c->{text}    : [ RGB_BLACK ] );
+   my $white = $self->cconvert( $tl->{scolor} ? $tl->{scolor} : [ RGB_WHITE ] );
    my $font  = GD::Font->Tiny;
    my $fx    = (length($key)+1)*$font->width;
    my $x1    = $self->{width} - $fx;

--- a/t/02-securityimage.t
+++ b/t/02-securityimage.t
@@ -1,0 +1,280 @@
+use strict;
+use warnings;
+use Test::More tests => 35;
+use Cwd;
+use vars qw( $MAGICK_SKIP );
+use Carp qw(croak);
+use lib qw(
+   ..
+   ../t/lib
+      t/lib
+);
+use Test::GDSI;
+
+BEGIN {
+  do 't/magick.pl' || croak "Can not include t/magick.pl: $!";
+   require GD::SecurityImage;
+   import  GD::SecurityImage;
+}
+
+# used to evaluate expressions in void context
+sub void(&) {
+  $_[0]->();
+  ();
+}
+
+my $class = 'GD::SecurityImage';
+my $font  = getcwd.'/StayPuft.ttf';
+my $tapi  = 'Test::GDSI';
+
+IMPORT: {
+  $class->import('bad_arg');
+  is($GD::SecurityImage::BACKEND, 'GD', 'import() ignore bad arguments.');
+
+  eval { $class->import( backend => 'bad_arg' ) };
+  ok($@, 'import() die on invalid backend.');
+
+  $class->import();
+  is($GD::SecurityImage::BACKEND, 'GD', 'import() default backend.');
+
+  $class->import( backend => 'GD' );
+  is($GD::SecurityImage::BACKEND, 'GD', 'import() load valid backend.');
+}
+
+NEW: {
+  my $im = $class->new('bad_args');
+  is(ref($im), 'GD::SecurityImage', 'new() ignores bad arguments.');
+
+  # font option
+  $im = $class->new(font => 'Inexistent font');
+  ok($im->create('ttf')->gdbox_empty, "new() won't load invalid fonts.");
+
+  # gd_font option
+  $tapi->save(
+    $class->new(gd_font => 'inexistent')
+          ->random
+          ->create
+          ->out,
+    'default',
+    'gd_font',
+    0);
+
+  # angle option
+  eval { $class->new( angle => 361 ) };
+  ok($@, 'new() die on angle parameter out of range [0].');
+
+  eval { $class->new( angle => -361 ) };
+  ok($@, 'new() die on angle parameter out of range [1].');
+
+  my $c=0;
+  for my $angle (0, 45, 90, 135, 180, 225, 270 ,315, 360) {
+    $tapi->save(
+      $class->new(
+        scramble => 1,
+        width  => 300,
+        height => 100,
+        font   => $font,
+        angle  => $angle
+       )->random(sprintf("%03dDEG", $angle))
+        ->create(ttf => 'box', [63, 143, 167], [226, 223, 169])
+        ->info_text(
+          x     => 'left',
+          y     => 'down',
+          strip => 1,
+          text  => $angle,
+          gd    => 1,
+         )
+        ->out,
+      $angle,
+      "gd_ttf_angle",
+      $c++);
+  }
+}
+
+BACKENDS: {
+  open my $fh, '>', \my $output or croak "Can't open output.";
+  select $fh;
+  $class->backends();
+  select STDOUT;
+  close $fh;
+  ok(defined $output, 'backends() in void context.');
+};
+
+RANDOM: {
+  my $rand = void { $class->new->random("string") };
+  ok( !defined $rand, "random() undefined value in void context." );
+};
+
+CCONVERT: {
+  my $color = $class->new->cconvert('#0a0a0a');
+  ok($color, 'cconvert() convert color string using GD backend.');
+
+  $color = $class->new->cconvert('Invalid color');
+  ok($color == 1, 'cconvert() GD, returns default index on invalid args.');
+
+  $color = $class->new->_cconvert_new();
+  ok($color == 1, '_convert_new() GD, returns default index for invalid args.');
+}
+
+CREATE: {
+  my $im = $class->new->create('normal', 'style_unknown');
+  ok($im->isa($class), "create() won't die on unknown style.");
+}
+
+PARTICLE: {
+  eval { my $im = $class->new->particle };
+  ok($@, 'particle() dies if called before create');
+
+  my $im = void  { $class->new->create->particle };
+  ok( !defined $im, 'particle() returns undef in void context' );
+
+  eval {
+    local $SIG{__WARN__} = sub { croak shift };
+    my $im = $class->new(width => 5, height => 10);
+    $im->create->particle
+  };
+  ok($@, "particle() warns when using small dimensions.")
+}
+
+INFO_TEXT: {
+  eval { my  $im = $class->new->info_text };
+  ok($@, 'info_text() dies if info_text was called before create');
+
+  my $im = $class->new->create->info_text('invalid_argument');
+  ok(!defined $im, "info_text() won't continue with invalid arguments");
+
+  $im = $class->new->create->info_text;
+  ok($im->isa($class), 'info_text() with default parameters');
+
+  # use info_text with a given angle
+  $tapi->save(
+    $class->new(
+      angle  => 30,
+      width  => 300,
+      height => 100,
+      font   => $font,
+     )->random('MyTest')
+      ->create(ttf => 'ec', [84, 207, 112], [0,0,0])
+      ->info_text(
+        x     => 'left',
+        y     => 'down',
+        text  => 'IT angle',
+       )
+      ->out(force => 'png'),
+    'info_text',
+    'gd_ttf_angle',
+    30);
+}
+
+OUT: {
+  my ($img, $mime, $rnd) = $class->new->random->create->out( force => 'xpm' );
+  is($mime, 'png', 'out() unsupported file format defaults to PNG.');
+
+  ($img, $mime, $rnd) = $class->new->random->create->out('invalid_argument');
+  ok($img &&  $mime &&  $rnd, 'out() ignores invalid arguments');
+
+  ($img, $mime, $rnd) = $class->new->random->create->out(
+    force => 'jpeg',
+    compress => 10
+   );
+  ok($img && $mime && $rnd, 'out() jpeg compression support');
+}
+
+R2H: {
+  my @rgb = $class->new->r2h(255, 255);
+  ok( !@rgb, "r2h() won't process invalid RGB input." );
+}
+
+SKIP: {
+  if ( $MAGICK_SKIP ) {
+    skip( $MAGICK_SKIP . ' Skipping...', 1 );
+  }
+
+ MAGICK_IMPORT: {
+      $class->import( use_magick => 1 );
+      is($GD::SecurityImage::BACKEND, 'Magick', 'Magick import() backend.');
+    }
+
+ MAGICK_NEW: {
+    # angle option
+    my $c = 0;
+    for my $angle (0, 45, 90, 135, 180, 225, 270 ,315, 360) {
+      $tapi->save(
+        $class->new(
+          scramble => 1,
+          width  => 300,
+          height => 100,
+          font   => $font,
+          angle  => $angle
+         )->random(sprintf("%03dDEG", $angle))
+          ->create(ttf => 'box', [63, 143, 167], [226, 223, 169])
+          ->info_text(
+            x     => 'left',
+            y     => 'down',
+            strip => 1,
+            text  => "$angle Deg",
+           )
+          ->out(force => 'png'),
+        $angle,
+        "magick_ttf_angle",
+        $c++);
+    }
+
+    # font option
+    my $im= $class->new( font => 'Inexistent font' )->create('ttf');
+    ok($im->gdbox_empty ==  0, "Magick new() don't take invalid fonts.");
+  }
+
+ MAGICK_CCONVERT: {
+    eval { my $im = $class->new->cconvert(15) };
+    ok($@, "Magick cconvert() can't handle index values.");
+
+    my $color = $class->new->cconvert('Invalid color');
+    ok(defined $color, 'Magick cconvert() ignores invalid color as an argument.');
+
+    my $hex_color = '#0a0a0a';
+    $color = $class->new->cconvert($hex_color);
+    is($color, $hex_color, 'Magick cconvert() Convert color string.');
+
+    $color =  $class->new->_cconvert_new();
+    ok(defined $color, 'Magick _cconvert_new() may take no arguments');
+  }
+
+ MAGICK_INFO_TEXT: {
+    # use info_text with a given angle
+    $tapi->save(
+      $class->new(
+        angle  => 10,
+        width  => 300,
+        height => 100,
+       )->random('MyTest')
+        ->create
+        ->info_text(
+          x     => 'left',
+          y     => 'down',
+          text  => 'IT angle',
+         )
+        ->out(force => 'png'),
+      'info_text',
+      'magick_ttf_angle',
+      10);
+  }
+
+ MAGICK_OUT: {
+    my %test_out = (
+      'jpeg compression support.'       => [force => 'jpeg', compress => 10],
+      'gif output supported.'           => [force => 'gif'],
+      'gif compression support.',       => [force => 'gif', compress => 10],
+      'unknown format defaults to gif.' => [force => 'unknown'],
+      'ignores invalid arguments.',     => ['invalid argument'],
+     );
+
+    for my $test_name (keys %test_out) {
+      my ($img, $mime, $rnd) = $class->new->random->create->out(
+        @{ $test_out{$test_name} }
+       );
+      ok($img && $mime && $rnd, 'Magick out() ' . $test_name);
+    }
+  }
+}
+

--- a/t/03-info_text.t
+++ b/t/03-info_text.t
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl -w
 use strict;
 use warnings;
-use Test::More qw(no_plan);
+use Test::More tests => 1;
 use Cwd;
 use GD::SecurityImage;
 

--- a/t/04-backend.t
+++ b/t/04-backend.t
@@ -12,8 +12,8 @@ BEGIN {
 
    my %total = (
       magick => 2,
-      gd     => 2,
-      other  => 1,
+      gd     => 3,
+      other  => 2,
    );
 
    my $total  = 0;
@@ -27,12 +27,18 @@ BEGIN {
    my $eok = eval { $class->new };
    ok( $@, q{If there is an error == OK [since we didn't import() so far]} );
 
+   # At least we have 2 backends
+   my @be = $class->backends;
+   cmp_ok ( @be, '>=', 2, "At least 2 core backends expected.");
+
    # test if we've loaded the right library
    GD_TEST: {
       $class->import( use_magick => 0 );
       ok( $class->new->raw->isa('GD::Image' ), 'Loaded GD [1]' );
       $class->import( backend => 'GD' );
       ok( $class->new->raw->isa('GD::Image' ), 'Loaded GD [2]' );
+      $class->import( backend => undef );
+      ok($class->new->raw->isa('GD::Image'  ), 'Loaded GD [3]' );
    }
 
    SKIP: {

--- a/t/05-version.t
+++ b/t/05-version.t
@@ -5,18 +5,41 @@ use Test::More;
 use Cwd;
 use GD::SecurityImage;
 
-plan tests => 5;
+plan tests => 8;
+
+my @gt_version_tests = ('2.0', undef);
+my @lt_version_tests = ('3.0', undef);
 
 my $i = GD::SecurityImage->new;
 
-my $gt = $i->_versiongt('2.0');
-my $lt = $i->_versionlt('3.0');
-ok( defined $gt, 'GT defined' );
-ok( defined $lt, 'LT defined' );
+GT0: {
+  my $c = 0;
 
-GT: {
+  for my $ver (@gt_version_tests) {
+    my $gt = $i->_versiongt($ver);
+
+    ok( defined $gt, "GT defined [$c]" );
+    $c++;
+  }
+}
+
+LT0: {
+  my $c = 0;
+
+  for my $ver (@lt_version_tests) {
+    my $lt = $i->_versionlt($ver);
+
+    ok( defined $lt, "LT defined [$c]" );
+    $c++;
+  }
+}
+
+GT1: {
    local $GD::VERSION = '1.19';
    ok( $i->_versiongt('1.18'), 'GT 1.18' );
    ok( $i->_versiongt('1.19'), 'ok. _versiongt() if greater or equal to 1.19' );
    ok( $i->_versionlt('3.0' ), 'but this means "smaller than"' );
+
+   is( $i->_versiongt('2.0'), 0,
+       "ok. _versiongt() if isn't greater than to 2.00" );
 }

--- a/t/06-version_magick.t
+++ b/t/06-version_magick.t
@@ -6,7 +6,7 @@ use Test::More;
 use Cwd;
 use Carp qw( croak );
 use lib  qw( .. );
-use constant TOTAL_TESTS => 6;
+use constant TOTAL_TESTS => 13;
 
 BEGIN {
    do 't/magick.pl' || croak "Can not include t/magick.pl: $!";
@@ -24,17 +24,38 @@ BEGIN {
 
 exit if $MAGICK_SKIP;
 
+my @gt_version_tests = ('6.0'  , '.0.0','6.1.2.3.4', undef);
+my @lt_version_tests = ('6.4.3', '.4.3','6.1.2.3.4', undef);
+
 my $i = GD::SecurityImage->new;
 
-my $gt = $i->_versiongt('6.0');
-my $lt = $i->_versionlt('6.4.3');
-ok( defined $gt, 'GT defined' );
-ok( defined $lt, 'LT defined' );
+GT0: {
+  my $c = 0;
 
-GT: {
+  for my $ver (@gt_version_tests) {
+    my $gt = $i->_versiongt($ver);
+
+    ok( defined $gt, "GT defined [$c]" );
+    $c++;
+  }
+}
+
+LT0: {
+  my $c = 0;
+
+  for my $ver (@lt_version_tests) {
+    my $lt = $i->_versionlt($ver);
+
+    ok( defined $lt, "LT defined [$c]" );
+    $c++;
+  }
+}
+
+GT1: {
    local $Image::Magick::VERSION = '6.0.3';
    ok( $i->_versiongt( '6.0'   ), 'GT 6.0'   );
    ok( $i->_versiongt( '6.0.3' ), 'GT 6.0.3' );
    ok( $i->_versionlt( '6.2'   ), 'LT 6.2'   );
    ok( $i->_versionlt( '6.2.6' ), 'LT 6.2.6' );
+   ok( $i->_versiongt( '7.0.3' ) == 0, 'GT 7.0.3' );
 }

--- a/t/lib/Test/GDSI.pm
+++ b/t/lib/Test/GDSI.pm
@@ -21,7 +21,7 @@ sub GD::SecurityImage::CIT { # __check_info_text
 }
 
 sub styles {
-    return qw( default rect box circle ellipse ec );
+    return qw( default rect box circle ellipse ec blank );
 }
 
 sub options {
@@ -66,6 +66,7 @@ sub random {
         box     => 'BOX012',
         rect    => 'RECT01',
         default => 'DFAULT',
+        blank   => 'BLANK0',
     }
 }
 
@@ -129,6 +130,15 @@ sub rect {
             ->particle(100)->CIT
 }
 
+
+sub blank {
+    return GD::SecurityImage
+            ->new(lines => 10, Test::GDSI->options, send_ctobg => 0)
+            ->random(Test::GDSI->random->{blank})
+            ->create(normal => 'blank', [68,150,125], [255,0,0])
+            ->particle(500)->CIT
+}
+
 sub default { ## no critic (Subroutines::ProhibitBuiltinHomonyms)
     return GD::SecurityImage
             ->new(lines => 10, Test::GDSI->options, send_ctobg => 0)
@@ -177,6 +187,14 @@ sub rect {
             ->random(Test::GDSI->random->{rect})
             ->create(ttf => 'rect', [63, 143, 167], [226, 223, 169])
             ->particle(2000)->CIT
+}
+
+sub blank {
+    return GD::SecurityImage
+            ->new(lines => 10, Test::GDSI->set_options(thickness => 2)->options)
+            ->random(Test::GDSI->random->{blank})
+            ->create(ttf => 'blank', [68,150,125], [255,0,0])
+            ->particle(5000)->CIT
 }
 
 sub default { ## no critic (ProhibitBuiltinHomonyms)


### PR DESCRIPTION
Hi Burak, 

 This is a small contribution for the CPAN Pull Request challenge.

  The overall changes consist of adding new tests to the test suite
   in order to increase the score reported by `Devel::Cover'. Also
   fixed a couple of minor typos in the documentation. Finally made
   some minor changes in two of lib files for things that came up
   while writing the new tests.

   I named the new file `02-securityimage.t' because I wasn't sure
   what the convention was, but please feel free to only take the
   changes that you consider that might better serve this cool
   package.

   By the way, I didn't change the `VERSION' of the package, I thought
   that you might want to wait until more changes added to the
   package before upgrading the version.

   Here's a brief summary of the changes per file:
1. MANIFEST
   - Added the new file `02-securityimage.t'.
2. lib/GD/SecurityImage.pm
   - Removed test for `text_location' option, this seems to be replaced by the`info_text' method.
   - Test that angle falls within the [-360,360] range.
   - Fixed 2 minor typos in the documentation.
3. lib/GD/SecurityImage/GD.pm
   - `place_gd()' added default values to $black and $white.
4. t/02-securityimage.t
   - Added a number of tests for the library API. Mostly tests when passing invalid arguments, or testing various angle values, etc.
5. t/03-info_text.t
   - Defined test plan number
6. t/04-backend.t
   - Added 2 more tests.
     1. At least 2 core backends come with the distribution.
     2. Test what happens when trying to import undefined backend.
7.  t/05-version.t
   - Added 4 new tests for the version testing methods.
8.  t/06-version_magick.t
   - Added 7 new tests basically to test different valid and invalid version numbers
9. t/98-gd.t
   - Added tests for the blank style, also added test for different positioning of the info_text
10. t/99-magick.t
    - Added tests for the blank style, also added test for different positioning of the info_text
11. t/lib/Test/GDSI.pm
    - Added subs for creating `SecurityImage' objects using the blank style
